### PR TITLE
Parse single- and double-quoted strings separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "lookml-highlighter",
     "displayName": "LookML Highlighter",
     "description": "Syntax highlighting for LookML",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "publisher": "moseleyi",
     "engines": {
         "vscode": "^1.53.0"

--- a/syntaxes/lookml.tmLanguage.json
+++ b/syntaxes/lookml.tmLanguage.json
@@ -60,6 +60,7 @@
 							"patterns": [
 								{"include": "#variable"},
 								{"include": "#string"},
+								{"include": "#string_single"},
 								{"include": "#yesno"}
 							]
 						}
@@ -87,6 +88,7 @@
 								{"include": "#variable"},
 								{"include": "#operator"},
 								{"include": "#string"},
+								{"include": "#string_single"},
 								{"include": "#number"},
 								{"include": "#liquid_tags"},
 								{"include": "#liquid_output"},
@@ -109,13 +111,23 @@
 
 		"string": {
 			"name": "string.quoted.double.lookml",
-			"begin": "\"|\\'",
-			"end": "\"|\\'",
+			"begin": "\"",
+			"end": "\"",
 			"patterns": [
 				{"include": "#constant"},
 				{"include": "#liquid_output"}
 			]
 		},
+		
+		"string_single": {
+			"name": "string.quoted.single.lookml",
+			"begin": "'",
+			"end": "'",
+			"patterns": [
+				{"include": "#constant"},
+				{"include": "#liquid_output"}
+			]
+		},		
 
 		"number": {
 		  "match": "((-|\\+)\\s*)?[0-9]+(\\.[0-9]+)?",
@@ -146,6 +158,7 @@
 			},
 			"patterns": [
 				{"include": "#string"},
+				{"include": "#string_single"},
 				{
 					"name": "source.lookml.parameter.array.delimiter",
 					"match": "\\,"
@@ -176,6 +189,7 @@
 			"patterns": [
 				{"include": "#liquid_filter"},
 				{"include": "#string"},
+				{"include": "#string_single"},
 				{"include": "#operator"},
 				{"include": "#number"}
 			],
@@ -218,6 +232,7 @@
 			"patterns": [
 				{"include": "#variable"},
 				{"include": "#string"},
+				{"include": "#string_single"},
 				{"include": "#number"},
 				{"include": "#sql_constant"},
 				{"include": "#sql_keyword"},

--- a/theme/lookml-colour-theme.json
+++ b/theme/lookml-colour-theme.json
@@ -3,6 +3,7 @@
   "tokenColors": [
     {"scope": ["constant.numeric.lookml"],                "settings": {"foreground": "#36982D"}},
     {"scope": ["string.quoted.double.lookml"],            "settings": {"foreground": "#c77528"}},
+    {"scope": ["string.quoted.single.lookml"],            "settings": {"foreground": "#c77528"}},
     {"scope": ["source.lookml.scope"],                    "settings": {"foreground": "#aaaaaa"}},
     {"scope": ["source.lookml.scope.type"],               "settings": {"foreground": "#6997bf"}},
     {"scope": ["source.lookml.scope.name"],               "settings": {"foreground": "#555555"}},


### PR DESCRIPTION
* Create new `string_single` token
* Remove single quotes from parsing of `string` token